### PR TITLE
Only remove `request_stub` if it's present

### DIFF
--- a/lib/mock5.rb
+++ b/lib/mock5.rb
@@ -66,7 +66,9 @@ module Mock5
   def unmount(*apis)
     mounted_apis.intersection(apis).each do |api|
       mounted_apis.delete api
-      registry.remove_request_stub api.request_stub
+      if registry.request_stubs.include?(api.request_stub)
+        registry.remove_request_stub api.request_stub
+      end
     end
   end
 

--- a/spec/mock5_spec.rb
+++ b/spec/mock5_spec.rb
@@ -16,7 +16,6 @@ describe Mock5 do
 
   describe "API mgmt" do
     before do
-      WebMock::StubRegistry.instance.reset!
       described_class.instance_exec do
         if instance_variable_defined?(:@_mounted_apis)
           remove_instance_variable :@_mounted_apis
@@ -182,13 +181,28 @@ describe Mock5 do
         end
       end
 
-      before{ described_class.mount api, another_api }
+      context "#mount" do
+        before{ described_class.mount api, another_api }
 
-      it "stubs remote apis" do
-        expect(get("http://example.com/index.html?foo=bar")).to eq("index.html")
-        expect(post("http://example.com/submit/here?foo=bar")).to eq("submit")
-        expect(post("http://example.com/foo/bar?fizz=buzz")).to eq("bar")
-        expect(get("http://example.com/bar/foo")).to eq("foo")
+        it "stubs remote apis" do
+          expect(get("http://example.com/index.html?foo=bar")).to eq("index.html")
+          expect(post("http://example.com/submit/here?foo=bar")).to eq("submit")
+          expect(post("http://example.com/foo/bar?fizz=buzz")).to eq("bar")
+          expect(get("http://example.com/bar/foo")).to eq("foo")
+        end
+      end
+
+      context "#with_mounted" do
+        around do |example|
+          described_class.with_mounted api, another_api, &example
+        end
+
+        it "stubs remote apis" do
+          expect(get("http://example.com/index.html?foo=bar")).to eq("index.html")
+          expect(post("http://example.com/submit/here?foo=bar")).to eq("submit")
+          expect(post("http://example.com/foo/bar?fizz=buzz")).to eq("bar")
+          expect(get("http://example.com/bar/foo")).to eq("foo")
+        end
       end
     end
   end


### PR DESCRIPTION
If you tried to use `with_mounted` within Rspec you would get an error saying "Request stub xyz is not registered.". So this PR checks is the request_stub is present before removing it.
This issue happens because Webmock has an after hook on Rspec to always reset the mocks: https://github.com/bblimke/webmock/blob/7bc4f70eeaefcc86bd8a92b582b158cb70072d6d/lib/webmock/rspec.rb#L29